### PR TITLE
Fix default port

### DIFF
--- a/src/main/resources/config/config.yml
+++ b/src/main/resources/config/config.yml
@@ -1,7 +1,7 @@
 # Zabbix particulars
 protocol: "http"
 host: "localhost"
-port: 10050
+port: 80
 username: ""
 password: ""
 jsonRpcPath: "api_jsonrpc.php"


### PR DESCRIPTION
10050 is indeed Zabbix server port but  i is not used for Zabbix API which is based on the web frontend of Zabbix. I think 80 default would be better.